### PR TITLE
카카오 주소 검색 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.0.2'
     id 'io.spring.dependency-management' version '1.1.0'
+    id 'groovy'
 }
 
 group = 'com.example'
@@ -30,6 +31,13 @@ dependencies {
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    //spock
+    testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
+    testImplementation 'org.spockframework:spock-spring:2.3-groovy-4.0'
+
+    //spock mock
+    testImplementation 'net.bytebuddy:byte-buddy:1.12.21'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/projectpoi/api/dto/DocumentsDto.java
+++ b/src/main/java/com/example/projectpoi/api/dto/DocumentsDto.java
@@ -1,0 +1,21 @@
+package com.example.projectpoi.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DocumentsDto {
+
+    @JsonProperty("address_name")
+    private String addressName;
+
+    @JsonProperty("x")
+    private Double longitude;
+
+    @JsonProperty("y")
+    private Double latitude;
+}

--- a/src/main/java/com/example/projectpoi/api/dto/KakaoSearchAddressResponse.java
+++ b/src/main/java/com/example/projectpoi/api/dto/KakaoSearchAddressResponse.java
@@ -1,0 +1,20 @@
+package com.example.projectpoi.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class KakaoSearchAddressResponse {
+
+    @JsonProperty("meta")
+    private MetaDto metaDto;
+
+    @JsonProperty("documents")
+    private List<DocumentsDto> documentList;
+}

--- a/src/main/java/com/example/projectpoi/api/dto/MetaDto.java
+++ b/src/main/java/com/example/projectpoi/api/dto/MetaDto.java
@@ -1,0 +1,15 @@
+package com.example.projectpoi.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MetaDto {
+
+    @JsonProperty("total_count")
+    private Integer totalCount;
+}

--- a/src/main/java/com/example/projectpoi/api/service/KakaoSearchAddressService.java
+++ b/src/main/java/com/example/projectpoi/api/service/KakaoSearchAddressService.java
@@ -1,0 +1,42 @@
+package com.example.projectpoi.api.service;
+
+import com.example.projectpoi.api.dto.KakaoSearchAddressResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoSearchAddressService {
+
+    private final RestTemplate restTemplate;
+
+    private final UriBuilderService uriBuilderService;
+
+    @Value("${kakao.rest.api.key}")
+    private String kakaoRestApiKey;
+
+    public KakaoSearchAddressResponse requestSearchAddress(String address) {
+        if (ObjectUtils.isEmpty(address)) {
+            return null;
+        }
+
+        URI uri = uriBuilderService.buildUriByAddress(address);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "KakaoAK " + kakaoRestApiKey);
+
+        HttpEntity httpEntity = new HttpEntity(headers);
+
+        return restTemplate.exchange(uri, HttpMethod.GET, httpEntity, KakaoSearchAddressResponse.class).getBody();
+    }
+}

--- a/src/main/java/com/example/projectpoi/api/service/UriBuilderService.java
+++ b/src/main/java/com/example/projectpoi/api/service/UriBuilderService.java
@@ -1,0 +1,24 @@
+package com.example.projectpoi.api.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Slf4j
+@Service
+public class UriBuilderService {
+
+    private static final String KAKAO_LOCAL_SEARCH_ADDRESS_URL = "https://dapi.kakao.com/v2/local/search/address.json";
+
+    public URI buildUriByAddress(String address) {
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(KAKAO_LOCAL_SEARCH_ADDRESS_URL);
+        builder.queryParam("query", address);
+
+        URI uri = builder.build().encode().toUri();
+        log.info("[UriBuilderService buildUriByAddress] address: {}, uri: {}", address, uri);
+
+        return uri;
+    }
+}

--- a/src/main/java/com/example/projectpoi/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/projectpoi/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.example.projectpoi.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,6 +14,11 @@ spring:
     activate:
       on-profile: common
 
+kakao:
+  rest:
+    api:
+      key: ${KAKAO_REST_API_KEY}
+
 ---
 
 spring:

--- a/src/test/groovy/com/example/projectpoi/api/service/KakaoSearchAddressServiceTest.groovy
+++ b/src/test/groovy/com/example/projectpoi/api/service/KakaoSearchAddressServiceTest.groovy
@@ -1,0 +1,33 @@
+package com.example.projectpoi.api.service
+
+import com.example.projectpoi.IntegrationContainerBaseTest
+import org.springframework.beans.factory.annotation.Autowired
+
+class KakaoSearchAddressServiceTest extends IntegrationContainerBaseTest {
+
+    @Autowired
+    private KakaoSearchAddressService kakaoSearchAddressService
+
+    def "address 값이 null 이면, requestSearchAddress() 메서드는 null 값을 반환한다."() {
+        given:
+        String address = null
+
+        when:
+        def result = kakaoSearchAddressService.requestSearchAddress(address)
+
+        then:
+        result == null
+    }
+
+    def "address 값이 정상이면, requestSearchAddress() 메서드는 meta 와 documents 데이터를 반환한다."() {
+        given:
+        String address = "경기 용인시 수지구 상현로 6"
+
+        when:
+        def result = kakaoSearchAddressService.requestSearchAddress(address)
+
+        then:
+        result.getMetaDto().getTotalCount() > 0
+        result.getDocumentList().size() > 0
+    }
+}

--- a/src/test/groovy/com/example/projectpoi/api/service/UriBuilderServiceTest.groovy
+++ b/src/test/groovy/com/example/projectpoi/api/service/UriBuilderServiceTest.groovy
@@ -1,0 +1,29 @@
+package com.example.projectpoi.api.service
+
+
+import org.springframework.boot.test.context.SpringBootTest
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+@SpringBootTest
+class UriBuilderServiceTest extends Specification {
+
+    private UriBuilderService uriBuilderService
+
+    def setup() {
+        uriBuilderService = new UriBuilderService()
+    }
+
+    def "URL 생성 테스트 - 한글 파라미터 인코딩 정상 case"() {
+        given:
+        String address = "경기 용인시 수지구"
+
+        when:
+        def uri = uriBuilderService.buildUriByAddress(address)
+        def decoded = URLDecoder.decode(uri.toString(), StandardCharsets.UTF_8)
+
+        then:
+        decoded == "https://dapi.kakao.com/v2/local/search/address.json?query=" + address
+    }
+}


### PR DESCRIPTION
카카오 주소 검색 API 를 프로젝트에서 사용하기 위해 설정을 추가하고, 주소 검색 API 호출 서비스를 개발해 보았다.

- application.yaml 에 REST API 키 등록 (보안을 위해 환경변수로 주입)
- 카카오 주소 검색 API 관련 dto, uri builder, api 호출 서비스 작성
- spock framework 를 이용한 테스트 코드 작성

spock 를 사용해서 테스트 해 본 것은 처음인데, 꽤 편리한 것 같다.

This closes #5 