### PR TITLE
Testcontainers 통합 테스트 환경 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ dependencies {
 
     //spock mock
     testImplementation 'net.bytebuddy:byte-buddy:1.12.21'
+
+    //testcontainers
+    testImplementation 'org.testcontainers:spock:1.17.6'
+    testImplementation 'org.testcontainers:mariadb:1.17.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/projectpoi/domain/Poi.java
+++ b/src/main/java/com/example/projectpoi/domain/Poi.java
@@ -1,0 +1,54 @@
+package com.example.projectpoi.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(
+        indexes = {
+                @Index(columnList = "poiType")
+        }
+)
+@Entity
+public class Poi {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    @Enumerated(EnumType.STRING) //ORDINAL 옵션은 순서가 바뀔 경우 문제가 발생하므로, STRING 옵션 적용
+    private PoiType poiType;
+
+    @Column
+    private String address;
+
+    @Column
+    private String name;
+
+    @Column
+    private Double longitude;
+
+    @Column
+    private Double latitude;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Poi poi)) return false;
+        return id.equals(poi.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/example/projectpoi/domain/PoiType.java
+++ b/src/main/java/com/example/projectpoi/domain/PoiType.java
@@ -1,0 +1,14 @@
+package com.example.projectpoi.domain;
+
+import lombok.Getter;
+
+public enum PoiType {
+    LOTTERY("복권판매점");
+
+    @Getter
+    private final String description;
+
+    PoiType(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/example/projectpoi/repository/PoiRepository.java
+++ b/src/main/java/com/example/projectpoi/repository/PoiRepository.java
@@ -1,0 +1,7 @@
+package com.example.projectpoi.repository;
+
+import com.example.projectpoi.domain.Poi;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PoiRepository extends JpaRepository<Poi, Long> {
+}

--- a/src/test/groovy/com/example/projectpoi/IntegrationContainerBaseTest.groovy
+++ b/src/test/groovy/com/example/projectpoi/IntegrationContainerBaseTest.groovy
@@ -1,0 +1,23 @@
+package com.example.projectpoi
+
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ContextConfiguration
+import org.testcontainers.containers.GenericContainer
+import spock.lang.Specification
+
+@ContextConfiguration //autowired
+@SpringBootTest
+abstract class IntegrationContainerBaseTest extends Specification {
+
+    static final GenericContainer REDIS_CONTAINER
+
+    static {
+        REDIS_CONTAINER = new GenericContainer<>("redis:7")
+            .withExposedPorts(6379)
+
+        REDIS_CONTAINER.start()
+
+        System.setProperty("spring.data.redis.host", REDIS_CONTAINER.getHost())
+        System.setProperty("spring.data.redis.port", REDIS_CONTAINER.getMappedPort(6379).toString())
+    }
+}

--- a/src/test/groovy/com/example/projectpoi/repository/PoiRepositoryTest.groovy
+++ b/src/test/groovy/com/example/projectpoi/repository/PoiRepositoryTest.groovy
@@ -1,0 +1,100 @@
+package com.example.projectpoi.repository
+
+import com.example.projectpoi.IntegrationContainerBaseTest
+import com.example.projectpoi.domain.Poi
+import com.example.projectpoi.domain.PoiType
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+class PoiRepositoryTest extends IntegrationContainerBaseTest {
+
+    @Autowired
+    private PoiRepository poiRepository
+
+    def "JPA Repository 테스트 - save"() {
+        given:
+        PoiType poiType = PoiType.LOTTERY
+        String address = "대구 달서구 대명천로 220"
+        String name = "일등복권편의점"
+        Double x = 128.536200
+        Double y = 35.8422196
+
+        def poi = Poi.builder()
+                .poiType(poiType)
+                .address(address)
+                .name(name)
+                .longitude(x)
+                .latitude(y)
+                .build()
+
+        when:
+        def save = poiRepository.save(poi)
+
+
+        println poi.getId()
+
+        then:
+        save == poi
+        save.getId() == poi.getId()
+        save.getPoiType() == poi.getPoiType()
+        save.getAddress() == poi.getAddress()
+        save.getName() == poi.getName()
+        save.getLongitude() == poi.getLongitude()
+        save.getLatitude() == poi.getLatitude()
+    }
+
+    def "JPA Repository 테스트 - findAll"() {
+        given:
+        PoiType poiType = PoiType.LOTTERY
+        String address = "대구 달서구 대명천로 220"
+        String name = "일등복권편의점"
+        Double x = 128.536200
+        Double y = 35.8422196
+
+        def poi = Poi.builder()
+                .poiType(poiType)
+                .address(address)
+                .name(name)
+                .longitude(x)
+                .latitude(y)
+                .build()
+
+        when:
+        poiRepository.save(poi)
+
+        println poi.getId()
+
+        then:
+        poiRepository.findAll().size() == 1;
+    }
+
+    def "JPA Repository 테스트 - update"() {
+        given:
+        PoiType poiType = PoiType.LOTTERY
+        String address = "대구 달서구 대명천로 220"
+        String name = "일등복권편의점"
+        Double x = 128.536200
+        Double y = 35.8422196
+
+        def poi = Poi.builder()
+                .poiType(poiType)
+                .address(address)
+                .name(name)
+                .longitude(x)
+                .latitude(y)
+                .build()
+
+        poiRepository.save(poi)
+
+
+        println poi.getId()
+        when:
+        poi.name += " new"
+        poiRepository.flush()
+
+        then:
+        def find = poiRepository.findById(poi.id).orElseThrow()
+        find.name == "일등복권편의점 new"
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    url: jdbc:tc:mariadb:10:///
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+
+kakao:
+  rest:
+    api:
+      key: ${KAKAO_REST_API_KEY}


### PR DESCRIPTION
Testcontainers 를 이용한 통합 테스트 환경을 구성하고, JPA Repository 테스트를 작성했다.
mariadb 의 경우 yaml 설정으로 추가가 가능하나, Redis 는 별도의 GenericContainer 를 생성해 프로퍼티로 주입받아서 테스트를 수행하는 방식이다.

- 통합 테스트 환경 설정
- domain, repository 개발
- 통합 테스트용 application.yaml 파일 작성
- 통합 테스트 작성

This closes #7 